### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> color_eyre::Result<()> {
 }
 
 fn check_permissions() -> bool {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     let is_admin = get_current_uid() == 0;
 
     is_admin


### PR DESCRIPTION
The privilege check on Linux is the same on FreeBSD. The tool runs fine on both systems.