### PR TITLE
windows: Build without uzers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ smbios-lib = { git = "https://github.com/FrameworkComputer/smbios-lib.git", bran
 color-eyre = "0.6.5"
 tokio = { version = "1.47.1", features = ["full"] }
 futures = "0.3.31"
-uzers = { version = "0.12.1", default-features = false }
 tui-popup = "0.6.0"
+
+[target.'cfg(unix)'.dependencies]
+uzers = { version = "0.12.1", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,12 @@
 use framework_tool_tui::app::App;
+#[cfg(unix)]
 use uzers::get_current_uid;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
-    if !check_permissions() {
-        return Err(color_eyre::Report::msg(
-            "The application needs to be run with root privileges.",
-        ));
-    }
+    check_permissions()?;
 
     let mut terminal = ratatui::init();
     let mut app = App::new()?;
@@ -21,9 +18,27 @@ async fn main() -> color_eyre::Result<()> {
     result
 }
 
-fn check_permissions() -> bool {
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(unix)]
+fn check_permissions() -> color_eyre::Result<()> {
     let is_admin = get_current_uid() == 0;
 
-    is_admin
+    if !is_admin {
+        return Err(color_eyre::Report::msg(
+            "The application needs to be run with root privileges.",
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn check_permissions() -> color_eyre::Result<()> {
+    if let Err(err) = framework_lib::chromium_ec::CrosEc::new().version_info() {
+        return Err(color_eyre::Report::msg(format!(
+            "The application needs to be run as admin: {:?}.",
+            err
+        )));
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Instead of including windows dependencies, just check if it works and report an error.

If the driver is not available for that platform. The error message from framework_lib will say that. That's why I also print that.